### PR TITLE
Feat: add support for par slices

### DIFF
--- a/util/slices/parallel.go
+++ b/util/slices/parallel.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slices
+
+import (
+	"sync"
+)
+
+// DefaultParallelism default parallelism for par
+const DefaultParallelism = 5
+
+// ParConfig config for par execution
+type ParConfig struct {
+	parallelism int
+}
+
+// NewParConfig build config for par execution
+func NewParConfig(opts ...ParOption) *ParConfig {
+	cfg := &ParConfig{
+		parallelism: DefaultParallelism,
+	}
+	for _, opt := range opts {
+		opt.ApplyTo(cfg)
+	}
+	return cfg
+}
+
+// ParOption options for par execution
+type ParOption interface {
+	ApplyTo(*ParConfig)
+}
+
+// Parallelism specify the parallelism of par execution
+type Parallelism int
+
+// ApplyTo .
+func (in Parallelism) ApplyTo(cfg *ParConfig) {
+	cfg.parallelism = int(in)
+}
+
+// ParFor run parallel executions for items in arr
+func ParFor[T any](arr []T, fn func(T), opts ...ParOption) {
+	cfg := NewParConfig(opts...)
+	pool := make(chan struct{}, cfg.parallelism)
+	wg := sync.WaitGroup{}
+	wg.Add(len(arr))
+	for _, item := range arr {
+		go func(i T) {
+			pool <- struct{}{}
+			fn(i)
+			<-pool
+			wg.Done()
+		}(item)
+	}
+	wg.Wait()
+	close(pool)
+}
+
+type ordered[V any] struct {
+	idx  int
+	item V
+}
+
+func toOrdered[V any](arr []V) []ordered[V] {
+	var _arr []ordered[V]
+	for idx, item := range arr {
+		_arr = append(_arr, ordered[V]{idx: idx, item: item})
+	}
+	return _arr
+}
+
+// ParMap run parallel mapping functions for arr, returned values are ordered
+func ParMap[T any, V any](arr []T, fn func(T) V, opts ...ParOption) []V {
+	outs := make(chan ordered[V])
+	go ParFor(toOrdered(arr), func(i ordered[T]) {
+		outs <- ordered[V]{idx: i.idx, item: fn(i.item)}
+	}, opts...)
+	_arr := make([]V, len(arr))
+	for range arr {
+		out := <-outs
+		_arr[out.idx] = out.item
+	}
+	close(outs)
+	return _arr
+}

--- a/util/slices/parallel_test.go
+++ b/util/slices/parallel_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slices_test
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
+
+	"github.com/kubevela/pkg/util/slices"
+)
+
+func TestParMap(t *testing.T) {
+	type input struct {
+		a int
+		b int
+		c float64
+		d *int
+	}
+	var inputs []input
+	size := 100
+	parallelism := 20
+	for i := 0; i < size; i++ {
+		if i%2 == 0 {
+			inputs = append(inputs, input{i, i + 1, math.Sqrt(float64(i)), nil})
+		} else {
+			inputs = append(inputs, input{i, i + 1, math.Sqrt(float64(i)), pointer.Int(i)})
+		}
+	}
+	outputs := slices.ParMap(inputs, func(i input) *float64 {
+		time.Sleep(time.Duration(rand.Intn(200)+25) * time.Millisecond)
+		if i.d == nil {
+			return nil
+		}
+		return pointer.Float64(float64(i.a*i.b) + i.c + float64(*i.d))
+	}, slices.Parallelism(parallelism))
+	r := require.New(t)
+	r.Equal(size, len(outputs))
+	for i, j := range outputs {
+		if i%2 == 0 {
+			r.Nil(j)
+		} else {
+			r.NotNil(j)
+			r.Equal(float64(i*(i+1))+math.Sqrt(float64(i))+float64(i), *j)
+		}
+	}
+}
+
+func TestParFor(t *testing.T) {
+	type input struct{ key int }
+	var inputs []input
+	size := 100
+	for i := 0; i < size; i++ {
+		inputs = append(inputs, input{i})
+	}
+	slices.ParFor(inputs, func(obj input) {
+		time.Sleep(time.Duration(rand.Intn(50)+size-obj.key) * time.Millisecond)
+	}, slices.Parallelism(20))
+}

--- a/util/slices/utils.go
+++ b/util/slices/utils.go
@@ -24,3 +24,43 @@ func Map[T any, V any](arr []T, fn func(T) V) []V {
 	}
 	return _arr
 }
+
+// Filter functional filter for array items
+func Filter[T any](arr []T, fn func(T) bool) []T {
+	var _arr []T
+	for _, item := range arr {
+		if fn(item) {
+			_arr = append(_arr, item)
+		}
+	}
+	return _arr
+}
+
+// Index search the index of array item with function
+func Index[T any](arr []T, fn func(T) bool) int {
+	for idx, item := range arr {
+		if fn(item) {
+			return idx
+		}
+	}
+	return -1
+}
+
+// Find search the first item with function
+func Find[T any](arr []T, fn func(T) bool) *T {
+	if idx := Index(arr, fn); idx >= 0 {
+		return &arr[idx]
+	}
+	return nil
+}
+
+// Flatten the given arr
+func Flatten[T any](arr [][]T) []T {
+	var _arr []T
+	for _, items := range arr {
+		for _, item := range items {
+			_arr = append(_arr, item)
+		}
+	}
+	return _arr
+}

--- a/util/slices/utils_test.go
+++ b/util/slices/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
 
 	"github.com/kubevela/pkg/util/slices"
 )
@@ -30,4 +31,38 @@ func TestMap(t *testing.T) {
 		return fmt.Sprintf("val:%d", i)
 	})
 	require.Equal(t, []string{"val:1", "val:2", "val:3"}, arr)
+}
+
+func TestFilter(t *testing.T) {
+	arr := slices.Filter([]int{1, 2, 3}, func(i int) bool {
+		return i%2 == 1
+	})
+	require.Equal(t, []int{1, 3}, arr)
+}
+
+func TestIndex(t *testing.T) {
+	idx := slices.Index([]int{1, 2, 3}, func(i int) bool {
+		return i%2 == 0
+	})
+	require.Equal(t, 1, idx)
+	idx = slices.Index([]int{1, 2, 3}, func(i int) bool {
+		return i%4 == 0
+	})
+	require.Equal(t, -1, idx)
+}
+
+func TestFind(t *testing.T) {
+	val := slices.Find([]int{1, 2, 3}, func(i int) bool {
+		return i%2 == 0
+	})
+	require.Equal(t, pointer.Int(2), val)
+	val = slices.Find([]int{1, 2, 3}, func(i int) bool {
+		return i%4 == 0
+	})
+	require.Nil(t, val)
+}
+
+func TestFlatten(t *testing.T) {
+	arr := slices.Flatten([][]int{{1, 2, 3}, {2, 4, 6}})
+	require.Equal(t, []int{1, 2, 3, 2, 4, 6}, arr)
 }


### PR DESCRIPTION
Signed-off-by: Yin Da <yd219913@alibaba-inc.com>

1. support `slices.Filter`, `slices.Index`, `slices.Find`, `slices.Flatten`
2. supprot `slices.ParFor`, `slices.ParMap` (Parallel Execution) for array items.