### PR TITLE
Feat: support cue printer & add support for protocol https

### DIFF
--- a/apis/cue/v1alpha1/package_types.go
+++ b/apis/cue/v1alpha1/package_types.go
@@ -48,6 +48,8 @@ const (
 	ProtocolGRPC ProviderProtocol = "grpc"
 	// ProtocolHTTP protocol type http for external Provider
 	ProtocolHTTP ProviderProtocol = "http"
+	// ProtocolHTTPS protocol type https for external Provider
+	ProtocolHTTPS ProviderProtocol = "https"
 )
 
 // Provider the external Provider in Package for cuex to run functions

--- a/cue/cuex/compiler.go
+++ b/cue/cuex/compiler.go
@@ -231,6 +231,7 @@ var (
 func AddFlags(set *pflag.FlagSet) {
 	set.BoolVarP(&EnableExternalPackageForDefaultCompiler, "enable-external-cue-package", "", EnableExternalPackageForDefaultCompiler, "enable load external package for cuex default compiler")
 	set.BoolVarP(&EnableExternalPackageWatchForDefaultCompiler, "list-watch-external-cue-package", "", EnableExternalPackageWatchForDefaultCompiler, "enable watch external package changes for cuex default compiler")
+	set.BoolVarP(&cuexruntime.DefaultClientInsecureSkipVerify, "cuex-external-provider-insecure-skip-verify", "", cuexruntime.DefaultClientInsecureSkipVerify, "Set if the default external provider client of cuex should skip insecure verify")
 }
 
 // CompileString use cuex default compiler to compile cue string

--- a/cue/cuex/runtime/package.go
+++ b/cue/cuex/runtime/package.go
@@ -80,8 +80,10 @@ func (in *externalPackage) GetProviderFn(do string) ProviderFn {
 	if in.src.Spec.Provider == nil {
 		return nil
 	}
-	fn := ExternalProviderFn(*in.src.Spec.Provider)
-	return &fn
+	return &ExternalProviderFn{
+		Provider: *in.src.Spec.Provider,
+		Fn:       do,
+	}
 }
 
 func (in *externalPackage) GetName() string {

--- a/cue/cuex/runtime/provider.go
+++ b/cue/cuex/runtime/provider.go
@@ -19,6 +19,7 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,6 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kubevela/pkg/apis/cue/v1alpha1"
+	"github.com/kubevela/pkg/cue/cuex/providers"
+	"github.com/kubevela/pkg/util/singleton"
 )
 
 var _ ProviderFn = GenericProviderFn[any, any](nil)
@@ -58,21 +61,35 @@ var _ ProviderFn = (*ExternalProviderFn)(nil)
 // ExternalProviderFn external provider that implements ProviderFn interface
 type ExternalProviderFn v1alpha1.Provider
 
+// DefaultClientInsecureSkipVerify set if the default external provider client
+// use insecure-skip-verify
+var DefaultClientInsecureSkipVerify = true
+
+// DefaultClient client for dealing requests
+var DefaultClient = singleton.NewSingleton(func() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: DefaultClientInsecureSkipVerify},
+		},
+	}
+})
+
 // Call dial external endpoints by passing the json data of the input parameter,
 // then fill back returned values
 func (in *ExternalProviderFn) Call(ctx context.Context, value cue.Value) (cue.Value, error) {
-	bs, err := value.MarshalJSON()
+	params := value.LookupPath(cue.ParsePath(providers.ParamsKey))
+	bs, err := params.MarshalJSON()
 	if err != nil {
 		return value, err
 	}
 	switch in.Protocol {
-	case v1alpha1.ProtocolHTTP:
+	case v1alpha1.ProtocolHTTP, v1alpha1.ProtocolHTTPS:
 		req, err := http.NewRequest(http.MethodPost, in.Endpoint, bytes.NewReader(bs))
 		if err != nil {
 			return value, err
 		}
 		req.Header.Set("Content-Type", runtime.ContentTypeJSON)
-		resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+		resp, err := DefaultClient.Get().Do(req.WithContext(ctx))
 		if err != nil {
 			return value, err
 		}
@@ -89,7 +106,7 @@ func (in *ExternalProviderFn) Call(ctx context.Context, value cue.Value) (cue.Va
 	if err = json.Unmarshal(bs, ret); err != nil {
 		return value, err
 	}
-	return value.FillPath(cue.ParsePath(""), ret), nil
+	return value.FillPath(cue.ParsePath(providers.ReturnsKey), ret), nil
 }
 
 var _ ProviderFn = NativeProviderFn(nil)

--- a/cue/cuex/runtime/provider_test.go
+++ b/cue/cuex/runtime/provider_test.go
@@ -105,8 +105,10 @@ func TestExternalProviderFn(t *testing.T) {
 
 	// test normal
 	prd := runtime.ExternalProviderFn{
-		Protocol: v1alpha1.ProtocolHTTP,
-		Endpoint: server.URL,
+		Provider: v1alpha1.Provider{
+			Protocol: v1alpha1.ProtocolHTTP,
+			Endpoint: server.URL,
+		},
 	}
 	v := cuecontext.New().CompileString(`{
 		$params: input: "value"
@@ -150,16 +152,20 @@ func TestExternalProviderFn(t *testing.T) {
 
 	// test invalid protocol
 	prd = runtime.ExternalProviderFn{
-		Protocol: "-",
-		Endpoint: server.URL,
+		Provider: v1alpha1.Provider{
+			Protocol: "-",
+			Endpoint: server.URL,
+		},
 	}
 	_, err = prd.Call(context.Background(), v)
 	require.Error(t, fmt.Errorf("protocol - not supported yet"), err)
 
 	// test bad endpoint
 	prd = runtime.ExternalProviderFn{
-		Protocol: v1alpha1.ProtocolHTTP,
-		Endpoint: "?",
+		Provider: v1alpha1.Provider{
+			Protocol: v1alpha1.ProtocolHTTP,
+			Endpoint: "?",
+		},
 	}
 	_, err = prd.Call(context.Background(), v)
 	require.Error(t, err)

--- a/cue/cuex/suite_test.go
+++ b/cue/cuex/suite_test.go
@@ -44,8 +44,11 @@ func TestCuex(t *testing.T) {
 
 var _ = bootstrap.InitKubeBuilderForTest(bootstrap.WithCRDPath("../../crds/cue.oam.dev_packages.yaml"))
 
-type toUpperVar struct {
-	Input  string `json:"input"`
+type toUpperIn struct {
+	Input string `json:"input"`
+}
+
+type toUpperOut struct {
 	Output string `json:"output"`
 }
 
@@ -61,13 +64,13 @@ var _ = Describe("Test Cuex Compiler", func() {
 				writer.WriteHeader(400)
 				return
 			}
-			v := &toUpperVar{}
-			if err := json.Unmarshal(bs, v); err != nil {
+			in := &toUpperIn{}
+			if err := json.Unmarshal(bs, in); err != nil {
 				writer.WriteHeader(400)
 				return
 			}
-			v.Output = strings.ToUpper(v.Input)
-			if bs, err = json.Marshal(v); err != nil {
+			out := &toUpperOut{Output: strings.ToUpper(in.Input)}
+			if bs, err = json.Marshal(out); err != nil {
 				writer.WriteHeader(500)
 				return
 			}
@@ -90,8 +93,8 @@ var _ = Describe("Test Cuex Compiler", func() {
 					#ToUpper: {
 						#do: "toUpper"
 						#provider: "string-util"
-						input: string
-						output?: string
+						$params: input: string
+						$returns?: output: string
 					}
 				`,
 				},
@@ -127,10 +130,10 @@ var _ = Describe("Test Cuex Compiler", func() {
 		}
 
 		toUpper: sutil.#ToUpper & {
-			input: decode.$returns
+			$params: input: decode.$returns
 		}
 		
-		output: toUpper.output
+		output: toUpper.$returns.output
 	`)
 		Ω(err).To(Succeed())
 		s, err := v.LookupPath(cue.ParsePath("output")).String()

--- a/cue/util/printer.go
+++ b/cue/util/printer.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+
+	"cuelang.org/go/cue"
+	"sigs.k8s.io/yaml"
+)
+
+// PrintFormat format for printing cue.Value
+type PrintFormat string
+
+const (
+	// PrintFormatJson json
+	PrintFormatJson PrintFormat = "json"
+	// PrintFormatYaml yaml
+	PrintFormatYaml PrintFormat = "yaml"
+	// PrintFormatCue cue
+	PrintFormatCue PrintFormat = "cue"
+)
+
+// PrintConfig config for printing value
+type PrintConfig struct {
+	format PrintFormat
+	path   *cue.Path
+}
+
+// PrintOption options for printing value
+type PrintOption interface {
+	ApplyTo(*PrintConfig)
+}
+
+// WithFormat set format for the print value
+type WithFormat string
+
+// ApplyTo .
+func (in WithFormat) ApplyTo(cfg *PrintConfig) {
+	cfg.format = PrintFormat(in)
+}
+
+// WithPath set path for the print value
+type WithPath string
+
+// ApplyTo .
+func (in WithPath) ApplyTo(cfg *PrintConfig) {
+	p := strings.TrimSpace(string(in))
+	if len(p) > 0 {
+		path := cue.ParsePath(p)
+		cfg.path = &path
+	}
+}
+
+// NewPrintConfig create print config
+func NewPrintConfig(options ...PrintOption) *PrintConfig {
+	cfg := &PrintConfig{format: PrintFormatCue}
+	for _, op := range options {
+		op.ApplyTo(cfg)
+	}
+	return cfg
+}
+
+// Print print cue.Value
+func Print(value cue.Value, options ...PrintOption) ([]byte, error) {
+	cfg := NewPrintConfig(options...)
+	if cfg.path != nil {
+		value = value.LookupPath(*cfg.path)
+	}
+	switch cfg.format {
+	case PrintFormatJson:
+		return value.MarshalJSON()
+	case PrintFormatYaml:
+		bs, err := value.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		return yaml.JSONToYAML(bs)
+	default:
+		s, err := ToString(value)
+		return []byte(s), err
+	}
+}

--- a/cue/util/printer_test.go
+++ b/cue/util/printer_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2023 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util_test
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubevela/pkg/cue/util"
+	"github.com/kubevela/pkg/util/stringtools"
+)
+
+func TestPrint(t *testing.T) {
+	testcases := map[string]struct {
+		Path   string
+		Format string
+		Err    bool
+		Out    string
+	}{
+		"json": {
+			Format: "json",
+			Out:    `{"x":1,"z":{"s":"str"},"y":2}`,
+		},
+		"yaml": {
+			Format: "yaml",
+			Out: `
+				x: 1
+				"y": 2
+				z:
+				  s: str
+			`,
+		},
+		"cue": {
+			Format: "cue",
+			Out: `
+				x: 1
+				z: s: "str"
+				y: 2
+			`,
+		},
+		"path": {
+			Format: "json",
+			Path:   "z.s",
+			Out:    `"str"`,
+		},
+	}
+	ctx := cuecontext.New()
+	val := ctx.CompileString(`
+		x: *1 | int
+		y: x + 1
+		if y > 1 {
+			z: s: "str"
+		}
+	`)
+	for name, tt := range testcases {
+		t.Run(name, func(t *testing.T) {
+			bs, err := util.Print(val, util.WithFormat(tt.Format), util.WithPath(tt.Path))
+			if tt.Err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, stringtools.TrimLeadingIndent(tt.Out), stringtools.TrimLeadingIndent(string(bs)))
+		})
+	}
+}

--- a/util/test/bootstrap/kubebuilder.go
+++ b/util/test/bootstrap/kubebuilder.go
@@ -56,7 +56,11 @@ func InitKubeBuilderForTest(options ...InitKubeConfigOption) *rest.Config {
 		workDir, err := os.Getwd()
 		Ω(err).To(Succeed())
 		if initCfg.crdPath != nil {
-			testEnv.CRDDirectoryPaths = []string{filepath.Join(workDir, *initCfg.crdPath)}
+			path := *initCfg.crdPath
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(workDir, *initCfg.crdPath)
+			}
+			testEnv.CRDDirectoryPaths = []string{path}
 		}
 		_cfg, err := testEnv.Start()
 		cfg = *_cfg


### PR DESCRIPTION
1. External provider use `$params` as input and `$returns` as output.
2. Support https protocol for external provider. By default, it will use insecure-skip-verify.
3. Split cue printer into separate functions.
4. Update CI bootstrap to allow absolute crd path.
5. External provider will inject "#do" value to http request header "CueX-External-Provider-Function".