### PR TITLE
Chore: Update Github Actions cache from deprecated v2 to v4

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
 
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
### Description of your changes

Builds are failing due to deprecated Github cache action. [Example](https://github.com/kubevela/pkg/actions/runs/13830772326)

Bump version to v4

### How has this code been tested
N/A

### Special notes for your reviewer
Matching [kubevela version](https://github.com/kubevela/kubevela/blob/master/.github/workflows/unit-test.yml#L55). 