### PR TITLE
Feat: Add OTel Tracing Headers and Baggage with CueX Requests

### DIFF
--- a/cue/cuex/externalserver/server.go
+++ b/cue/cuex/externalserver/server.go
@@ -19,6 +19,7 @@ package externalserver
 import (
 	"context"
 	"encoding/json"
+	"github.com/kubevela/pkg/cue/cuex/runtime"
 	"io"
 	"net/http"
 
@@ -39,6 +40,8 @@ type GenericServerProviderFn[T any, U any] func(context.Context, *T) (*U, error)
 
 // Call handle rest call for given request
 func (fn GenericServerProviderFn[T, U]) Call(request *restful.Request, response *restful.Response) {
+	ctx := runtime.ContextFromHeaders(request.Request)
+	request.Request = request.Request.WithContext(ctx)
 	bs, err := io.ReadAll(request.Request.Body)
 	if err != nil {
 		_ = response.WriteError(http.StatusBadRequest, err)

--- a/cue/cuex/runtime/tracer.go
+++ b/cue/cuex/runtime/tracer.go
@@ -1,0 +1,200 @@
+package runtime
+
+import (
+	"context"
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/propagation"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"k8s.io/klog"
+	"net/http"
+	"strings"
+)
+
+var newBaggageMember = baggage.NewMember // function injection for tests
+var newBaggage = baggage.New             // function injection for tests
+
+func init() {
+	// set the default OTel implementation if the controller did not already handle the setup
+	// fallback functionality - preferred to update the controller to handle this
+	oTelTracerProviderSet := otel.GetTracerProvider().Tracer("check") != otel.Tracer("check")
+	if !oTelTracerProviderSet {
+		tp := tracesdk.NewTracerProvider()
+		otel.SetTracerProvider(tp)
+	}
+}
+
+type ctxKey string
+
+// PropagatedCtx .
+type PropagatedCtx struct {
+	pCtx []byte
+	context.Context
+}
+
+const (
+	key          ctxKey = "PropagatedCtx"
+	headerPrefix        = "X-Vela"
+	traceParent         = "traceparent"
+	traceState          = "tracestate"
+	encodedCtx          = "Encoded-Context"
+)
+
+// StartSpan creates a new OpenTelemetry span and returns the updated context and span.
+func StartSpan(ctx context.Context, name string) (context.Context, trace.Span) {
+	tracer := otel.Tracer(name)
+	ctx, span := tracer.Start(ctx, name)
+	return ctx, span
+}
+
+// StartSpanWithBaggage creates a new OpenTelemetry span and attaches encoded JSON context as baggage.
+func StartSpanWithBaggage(ctx context.Context, name string, hCtx json.Marshaler) (context.Context, trace.Span, error) {
+	jsonCtx, err := json.Marshal(hCtx)
+	if err != nil {
+		klog.Errorf("failed to marshal json: %v", err)
+		ctx, span := StartSpan(ctx, name)
+		return ctx, span, err
+	}
+
+	member, err := newBaggageMember(strings.ToLower(encodedCtx), base64.StdEncoding.EncodeToString(jsonCtx))
+	if err != nil {
+		klog.Warningf("failed to encode context baggage header: \n%v", err)
+	} else {
+		bag, err := newBaggage(member)
+		if err != nil {
+			klog.Errorf("failed to create context bag: \n%v", err)
+			ctx, span := StartSpan(ctx, name)
+			return ctx, span, err
+		}
+		ctx = baggage.ContextWithBaggage(ctx, bag)
+	}
+
+	ctx, span := StartSpan(ctx, name)
+	return ctx, span, err
+}
+
+// WithBaggage appends additional baggage entries to the context.
+func WithBaggage(ctx context.Context, b map[string]string) (context.Context, error) {
+	members := baggage.FromContext(ctx).Members()
+	var failures []string
+	for k, v := range b {
+		m, err := newBaggageMember(k, v)
+		if err != nil {
+			klog.Errorf("failed to create new member\n%v", err)
+			failures = append(failures, fmt.Sprintf("failed to create new member %s = %s", k, v))
+			continue
+		}
+		members = append(members, m)
+	}
+	bag, err := newBaggage(members...)
+	if err != nil {
+		klog.Errorf("failed to create context bag: \n%v", err)
+		return ctx, err
+	}
+
+	if len(failures) > 0 {
+		klog.Warningf("Baggage created with failed members!")
+		return baggage.ContextWithBaggage(ctx, bag), errors.New(strings.Join(failures, "\n"))
+	}
+	return baggage.ContextWithBaggage(ctx, bag), nil
+}
+
+// TraceHeaderPropagator .
+type TraceHeaderPropagator struct {
+	traceContextPropagator propagation.TraceContext
+}
+
+// Inject serializes the span baggage and trace context into the provided HTTP headers.
+func (cp TraceHeaderPropagator) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
+	bag := baggage.FromContext(ctx)
+	for _, member := range bag.Members() {
+		headerName := fmt.Sprintf("%s-%s", headerPrefix, member.Key())
+		carrier.Set(headerName, member.Value())
+	}
+	cp.traceContextPropagator.Inject(ctx, carrier)
+}
+
+// Extract reconstructs the span context and baggage from the provided HTTP headers.
+func (cp TraceHeaderPropagator) Extract(ctx context.Context, carrier propagation.TextMapCarrier) context.Context {
+	ctx = TraceHeaderPropagator{}.traceContextPropagator.Extract(ctx, carrier)
+	appContext := &PropagatedCtx{
+		Context: ctx,
+	}
+	for _, hKey := range carrier.Keys() {
+		value := carrier.Get(hKey)
+		if strings.HasPrefix(hKey, headerPrefix) {
+			strippedKey := strings.TrimPrefix(hKey, headerPrefix+"-")
+
+			switch strippedKey {
+
+			case encodedCtx:
+				dataBytes, err := base64.StdEncoding.DecodeString(value)
+				if err != nil {
+					klog.Errorf("error decoding base64 context: %v\n", err)
+					continue
+				}
+				appContext.pCtx = dataBytes
+
+			case traceParent, traceState: // do nothing
+
+			default:
+				appContext.Context = context.WithValue(appContext.Context, strings.ToLower(strippedKey), value)
+			}
+		}
+	}
+
+	return context.WithValue(ctx, key, appContext)
+}
+
+// RawJSON returns the embedded JSON context as a json.RawMessage.
+func (p *PropagatedCtx) RawJSON() json.RawMessage {
+	return json.RawMessage(p.pCtx)
+}
+
+// UnmarshalContext unmarshals the embedded JSON context into the provided struct.
+func (p *PropagatedCtx) UnmarshalContext(out interface{}) error {
+	return json.Unmarshal(p.pCtx, out)
+}
+
+// GetCueContext returns the embedded JSON context as a CUE value.
+func (p *PropagatedCtx) GetCueContext() (*cue.Value, error) {
+	cueCtx := cuecontext.New()
+	cueVal := cueCtx.CompileString(string(p.pCtx))
+	if cueVal.Err() != nil {
+		return &cue.Value{}, cueVal.Err()
+	}
+	return &cueVal, nil
+}
+
+// ContextFromHeaders extracts the span context and baggage from an HTTP request and returns the reconstructed ctx.
+func ContextFromHeaders(r *http.Request) context.Context {
+	return TraceHeaderPropagator{}.Extract(context.Background(), propagation.HeaderCarrier(r.Header))
+}
+
+// GetPropagatedContext retrieves the PropagatedCtx from the given context if present.
+func GetPropagatedContext(ctx context.Context) (*PropagatedCtx, bool) {
+	pCtx := ctx.Value(key)
+	if pCtx != nil {
+		if pc, ok := pCtx.(*PropagatedCtx); ok {
+			return pc, true
+		}
+		return &PropagatedCtx{pCtx: []byte("")}, false
+	}
+	return &PropagatedCtx{pCtx: []byte("")}, false
+}
+
+// Fields returns the list of HTTP headers used for trace context propagation.
+func (cp TraceHeaderPropagator) Fields() []string {
+	return []string{
+		traceParent,
+		traceState,
+		fmt.Sprintf("%s-%s", headerPrefix, encodedCtx),
+	}
+}

--- a/cue/cuex/runtime/tracer_test.go
+++ b/cue/cuex/runtime/tracer_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2025 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"cuelang.org/go/cue"
+	"encoding/json"
+	"errors"
+	"github.com/kubevela/pkg/apis/cue/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTracerNoBaggage(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NotNil(t, r.Header.Get("X-Vela-Encoded-Context"))
+		assert.NotNil(t, r.Header.Get("Traceparent"))
+
+		ctx := ContextFromHeaders(r)
+		_, _ = GetPropagatedContext(ctx)
+
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("{ \"response\": true }"))
+	}))
+
+	provider := v1alpha1.Provider{
+		Protocol: v1alpha1.ProtocolHTTP,
+		Endpoint: testServer.URL,
+	}
+
+	ctx, span := StartSpan(context.Background(), "span")
+	defer span.End()
+
+	_, ok := GetPropagatedContext(ctx)
+	assert.False(t, ok)
+	assert.True(t, span.SpanContext().SpanID().IsValid())
+	assert.True(t, span.SpanContext().TraceID().IsValid())
+
+	fn := ExternalProviderFn{
+		Provider: provider,
+		Fn:       "do",
+	}
+
+	_, err := fn.Call(ctx, cue.Value{})
+	require.NoError(t, err)
+}
+
+func TestTracerWithBaggage(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NotNil(t, r.Header.Get("X-Vela-Encoded-Context"))
+		assert.NotNil(t, r.Header.Get("Traceparent"))
+
+		ctx := ContextFromHeaders(r)
+
+		pCtx, ok := GetPropagatedContext(ctx)
+		assert.True(t, ok)
+
+		assert.NotNil(t, pCtx.RawJSON())
+
+		var mapCtx map[string]interface{}
+		err := pCtx.UnmarshalContext(&mapCtx)
+		assert.NoError(t, err)
+		assert.Equal(t, mapCtx["appName"], "app-name")
+		assert.Equal(t, mapCtx["namespace"], "a-namespace")
+
+		cueContext, err := pCtx.GetCueContext()
+		assert.NoError(t, err)
+		appName, err := cueContext.LookupPath(cue.ParsePath("appName")).String()
+		assert.NoError(t, err)
+		assert.Equal(t, "app-name", appName)
+		namespace, err := cueContext.LookupPath(cue.ParsePath("namespace")).String()
+		assert.NoError(t, err)
+		assert.Equal(t, "a-namespace", namespace)
+
+		tertiary := pCtx.Context.Value("tertiary")
+		assert.Equal(t, "value", tertiary)
+
+		span := trace.SpanFromContext(ctx)
+		assert.True(t, span.SpanContext().SpanID().IsValid())
+		assert.True(t, span.SpanContext().TraceID().IsValid())
+
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("{ \"response\": true }"))
+	}))
+
+	provider := v1alpha1.Provider{
+		Protocol: v1alpha1.ProtocolHTTP,
+		Endpoint: testServer.URL,
+	}
+
+	jsonCtx := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"appName":   "app-name",
+			"namespace": "a-namespace",
+		},
+	}
+
+	ctx, span, _ := StartSpanWithBaggage(context.Background(), "span", jsonCtx)
+	ctx, _ = WithBaggage(ctx, map[string]string{
+		"tertiary": "value",
+	})
+
+	defer span.End()
+
+	fn := ExternalProviderFn{
+		Provider: provider,
+		Fn:       "do",
+	}
+
+	_, err := fn.Call(ctx, cue.Value{})
+	require.NoError(t, err)
+}
+
+type dummyContext struct{}
+
+func (d dummyContext) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{"foo": "bar"})
+}
+
+func TestStartSpanWithBaggage_MemberError(t *testing.T) {
+	original := newBaggageMember
+	defer func() { newBaggageMember = original }()
+
+	newBaggageMember = func(k string, v string, props ...baggage.Property) (baggage.Member, error) {
+		return baggage.Member{}, errors.New("forced error")
+	}
+
+	ctx := context.Background()
+	ctx, span, err := StartSpanWithBaggage(ctx, "test-span", dummyContext{})
+	assert.Error(t, err)
+	assert.NotNil(t, span)
+	assert.True(t, span.SpanContext().SpanID().IsValid())
+	assert.True(t, span.SpanContext().TraceID().IsValid())
+
+	b := baggage.FromContext(ctx)
+	assert.Empty(t, b.Members())
+}
+
+func TestStartSpanWithBaggage_BaggageError(t *testing.T) {
+	original := newBaggage
+	defer func() { newBaggage = original }()
+
+	newBaggage = func(members ...baggage.Member) (baggage.Baggage, error) {
+		return baggage.Baggage{}, errors.New("forced error")
+	}
+
+	ctx := context.Background()
+	ctx, span, err := StartSpanWithBaggage(ctx, "test-span", dummyContext{})
+	assert.Error(t, err)
+	assert.NotNil(t, span)
+	assert.True(t, span.SpanContext().SpanID().IsValid())
+	assert.True(t, span.SpanContext().TraceID().IsValid())
+
+	b := baggage.FromContext(ctx)
+	assert.Empty(t, b.Members())
+}
+
+type jsonMarshalFailure struct{}
+
+func (d jsonMarshalFailure) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("failed")
+}
+
+func TestStartSpanWithBaggage_MarshalError(t *testing.T) {
+	ctx := context.Background()
+	ctx, span, err := StartSpanWithBaggage(ctx, "test-span", jsonMarshalFailure{})
+
+	assert.Error(t, err)
+	assert.NotNil(t, span)
+	assert.True(t, span.SpanContext().SpanID().IsValid())
+	assert.True(t, span.SpanContext().TraceID().IsValid())
+
+	b := baggage.FromContext(ctx)
+	assert.Empty(t, b.Members())
+}
+
+func TestWithBaggage_MemberError(t *testing.T) {
+	original := newBaggageMember
+	defer func() { newBaggageMember = original }()
+
+	newBaggageMember = func(k string, v string, props ...baggage.Property) (baggage.Member, error) {
+		if k == "fail" {
+			return baggage.Member{}, errors.New("forced error")
+		}
+		return original(k, v, props...)
+	}
+
+	bag := map[string]string{
+		"fail":   "failure",
+		"member": "value",
+	}
+
+	ctx := context.Background()
+	ctx, err := WithBaggage(ctx, bag)
+	assert.Error(t, err)
+
+	b := baggage.FromContext(ctx)
+	assert.Equal(t, "member", b.Members()[0].Key())
+	assert.Equal(t, "value", b.Members()[0].Value())
+}
+
+func TestWithBaggage_BaggageError(t *testing.T) {
+	original := newBaggage
+	defer func() { newBaggage = original }()
+
+	newBaggage = func(members ...baggage.Member) (baggage.Baggage, error) {
+		return baggage.Baggage{}, errors.New("forced error")
+	}
+
+	bag := map[string]string{
+		"member":  "value",
+		"another": "value",
+	}
+
+	ctx := context.Background()
+	ctx, err := WithBaggage(ctx, bag)
+	assert.Error(t, err)
+
+	b := baggage.FromContext(ctx)
+	assert.Empty(t, b.Members())
+}
+
+func TestExtract_InvalidBase64(t *testing.T) {
+	req, _ := http.NewRequest("GET", "https://test.com", nil)
+	req.Header.Set("X-Vela-Encoded-Context", "invalid base64!")
+
+	ctx := TraceHeaderPropagator{}.Extract(context.Background(), propagation.HeaderCarrier(req.Header))
+	pCtx, _ := GetPropagatedContext(ctx)
+
+	assert.Empty(t, pCtx.pCtx)
+}
+
+func TestGetCueContext_Invalid(t *testing.T) {
+	propagatedCtx := PropagatedCtx{pCtx: []byte("+++")}
+
+	val, err := propagatedCtx.GetCueContext()
+	assert.Error(t, err)
+	assert.False(t, val.Exists())
+}
+
+func TestGetPropagatedContext_WhenEmpty(t *testing.T) {
+	pCtx, ok := GetPropagatedContext(context.Background())
+	assert.False(t, ok)
+	assert.NotNil(t, pCtx)
+	assert.Empty(t, pCtx.pCtx)
+
+	cueContext, err := pCtx.GetCueContext()
+	assert.NoError(t, err)
+	assert.True(t, cueContext.Exists())
+
+	jsonContext := pCtx.RawJSON()
+	assert.Empty(t, jsonContext)
+}

--- a/go.mod
+++ b/go.mod
@@ -21,11 +21,15 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/otel v1.19.0
+	go.opentelemetry.io/otel/sdk v1.19.0
+	go.opentelemetry.io/otel/trace v1.19.0
 	go.uber.org/automaxprocs v1.5.3
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
 	k8s.io/apiserver v0.29.2
 	k8s.io/client-go v0.29.2
+	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.120.1
 	k8s.io/kubectl v0.29.0
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
@@ -92,12 +96,9 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.10 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0 // indirect
-	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.19.0 // indirect
-	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
@@ -124,7 +125,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.2 // indirect
 	k8s.io/component-base v0.29.2 // indirect
-	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kms v0.29.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	open-cluster-management.io/api v0.11.0 // indirect


### PR DESCRIPTION
### Description of your changes
Adds tracing and baggage (app context) support using OTel for outbound CueX requests. 
The externalserver package has been updated to reconstruct the context from the received headers. 

I have:
 - [x] Read and followed KubeVela's [contribution process](https://github.com/kubevela/kubevela/blob/master/contribute/create-pull-request.md).
 - [x] [Related Docs](https://github.com/kubevela/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
 - [x] Run make reviewable to ensure this PR is ready for review.
 - [ ] Added backport release-x.y labels to auto-backport this PR if necessary.

### How has this code been tested
PR includes unit tests for both the outbound and inbound functionality. 
Manual testing has been conducted to ship application workflow context & trace IDs from a Kubevela Application to a CueX server. 

### Special notes for your reviewer
N/A