### PR TITLE
DRAFT [Feat] Compiler Context to Support Compositions

### DIFF
--- a/cue/cuex/compiler.go
+++ b/cue/cuex/compiler.go
@@ -18,11 +18,14 @@ package cuex
 
 import (
 	"context"
+	"cuelang.org/go/cue/build"
+	compilercontext "github.com/kubevela/pkg/cue/cuex/context"
+	"github.com/kubevela/pkg/cue/cuex/interfaces"
+	"github.com/kubevela/pkg/cue/cuex/types"
 	"strings"
 	"time"
 
 	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/parser"
 	"github.com/spf13/pflag"
@@ -55,15 +58,9 @@ func (in *Compiler) CompileString(ctx context.Context, src string) (cue.Value, e
 	return in.CompileStringWithOptions(ctx, src)
 }
 
-// CompileConfig config for running compile process
-type CompileConfig struct {
-	ResolveProviderFunctions bool
-	PreResolveMutators       []func(context.Context, string) (string, error)
-}
-
 // NewCompileConfig create new CompileConfig
-func NewCompileConfig(opts ...CompileOption) *CompileConfig {
-	cfg := &CompileConfig{
+func NewCompileConfig(opts ...interfaces.CompileOption) *types.CompileConfig {
+	cfg := &types.CompileConfig{
 		ResolveProviderFunctions: true,
 		PreResolveMutators:       nil,
 	}
@@ -73,13 +70,8 @@ func NewCompileConfig(opts ...CompileOption) *CompileConfig {
 	return cfg
 }
 
-// CompileOption options for compile cue string
-type CompileOption interface {
-	ApplyTo(*CompileConfig)
-}
-
 // WithExtraData fill the cue.Value before resolve
-func WithExtraData(key string, data interface{}) CompileOption {
+func WithExtraData(key string, data interface{}) interfaces.CompileOption {
 	return &withExtraData{
 		key:  key,
 		data: data,
@@ -92,7 +84,7 @@ type withExtraData struct {
 }
 
 // ApplyTo .
-func (in *withExtraData) ApplyTo(cfg *CompileConfig) {
+func (in *withExtraData) ApplyTo(cfg *types.CompileConfig) {
 	cfg.PreResolveMutators = append(cfg.PreResolveMutators, func(_ context.Context, template string) (string, error) {
 		val, path := cuecontext.New().CompileString(""), cue.ParsePath(in.key)
 		if runtime.IsNil(in.data) {
@@ -105,19 +97,20 @@ func (in *withExtraData) ApplyTo(cfg *CompileConfig) {
 	})
 }
 
-var _ CompileOption = DisableResolveProviderFunctions{}
+var _ interfaces.CompileOption = DisableResolveProviderFunctions{}
 
 // DisableResolveProviderFunctions disable ResolveProviderFunctions
 type DisableResolveProviderFunctions struct{}
 
 // ApplyTo .
-func (in DisableResolveProviderFunctions) ApplyTo(cfg *CompileConfig) {
+func (in DisableResolveProviderFunctions) ApplyTo(cfg *types.CompileConfig) {
 	cfg.ResolveProviderFunctions = false
 }
 
 // CompileStringWithOptions compile given cue string with extra options
-func (in *Compiler) CompileStringWithOptions(ctx context.Context, src string, opts ...CompileOption) (cue.Value, error) {
+func (in *Compiler) CompileStringWithOptions(ctx context.Context, src string, opts ...interfaces.CompileOption) (cue.Value, error) {
 	var err error
+	compilercontext.WithCompiler(ctx, in) // set context for nested compilations
 	cfg := NewCompileConfig(opts...)
 	bi := build.NewContext().NewInstance("", nil)
 	bi.Imports = in.PackageManager.GetImports()
@@ -133,7 +126,12 @@ func (in *Compiler) CompileStringWithOptions(ctx context.Context, src string, op
 	if err = bi.AddSyntax(f); err != nil {
 		return cue.Value{}, err
 	}
-	val := cuecontext.New().BuildInstance(bi)
+	cueCtx := compilercontext.GetCueContext(ctx)
+	if cueCtx == nil {
+		cueCtx = cuecontext.New()
+		compilercontext.WithCueContext(ctx, cueCtx) // set the cue context for nested compilations
+	}
+	val := cueCtx.BuildInstance(bi)
 	if cfg.ResolveProviderFunctions {
 		return in.Resolve(ctx, val)
 	}
@@ -239,6 +237,6 @@ func CompileString(ctx context.Context, src string) (cue.Value, error) {
 }
 
 // CompileStringWithOptions use cuex default compiler to compile cue string with options
-func CompileStringWithOptions(ctx context.Context, src string, opts ...CompileOption) (cue.Value, error) {
+func CompileStringWithOptions(ctx context.Context, src string, opts ...interfaces.CompileOption) (cue.Value, error) {
 	return DefaultCompiler.Get().CompileStringWithOptions(ctx, src, opts...)
 }

--- a/cue/cuex/context/context.go
+++ b/cue/cuex/context/context.go
@@ -1,0 +1,32 @@
+package context
+
+import (
+	"context"
+	"cuelang.org/go/cue"
+	"github.com/kubevela/pkg/cue/cuex/interfaces"
+)
+
+type CompilerKey struct{}
+type CueContextKey struct{}
+
+func WithCueContext(ctx context.Context, cueCtx *cue.Context) context.Context {
+	return context.WithValue(ctx, CueContextKey{}, cueCtx)
+}
+
+func GetCueContext(ctx context.Context) *cue.Context {
+	if c, ok := ctx.Value(CueContextKey{}).(*cue.Context); ok {
+		return c
+	}
+	return nil
+}
+
+func WithCompiler(ctx context.Context, c interfaces.CueXCompiler) context.Context {
+	return context.WithValue(ctx, CompilerKey{}, c)
+}
+
+func GetCompiler(ctx context.Context) interfaces.CueXCompiler {
+	if c, ok := ctx.Value(CompilerKey{}).(interfaces.CueXCompiler); ok {
+		return c
+	}
+	return nil
+}

--- a/cue/cuex/interfaces/compiler.go
+++ b/cue/cuex/interfaces/compiler.go
@@ -1,0 +1,17 @@
+package interfaces
+
+import (
+	"context"
+	"cuelang.org/go/cue"
+	"github.com/kubevela/pkg/cue/cuex/types"
+)
+
+type CueXCompiler interface {
+	CompileString(ctx context.Context, src string) (cue.Value, error)
+	CompileStringWithOptions(ctx context.Context, src string, opts ...CompileOption) (cue.Value, error)
+}
+
+// CompileOption options for compile cue string
+type CompileOption interface {
+	ApplyTo(config *types.CompileConfig)
+}

--- a/cue/cuex/types/types.go
+++ b/cue/cuex/types/types.go
@@ -1,0 +1,9 @@
+package types
+
+import "context"
+
+// CompileConfig config for running compile process
+type CompileConfig struct {
+	ResolveProviderFunctions bool
+	PreResolveMutators       []func(context.Context, string) (string, error)
+}


### PR DESCRIPTION
Related KubeVela changes: https://github.com/kubevela/kubevela/pull/6989

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a compiler context to share the Cue context and compiler across nested compilations. This enables compositions to reuse state and resolve provider functions reliably.

- **New Features**
  - Added context helpers to set/get the compiler and cue.Context.
  - Compiler now uses a shared cue.Context when building instances and stores both in the request context.

- **Migration**
  - Use github.com/kubevela/pkg/cue/cuex/interfaces and github.com/kubevela/pkg/cue/cuex/types.
  - CompileStringWithOptions now takes opts ...interfaces.CompileOption.
  - Custom CompileOption implementations must apply to *types.CompileConfig.

<sup>Written for commit 2792b6f4f785751a2d9808c57cf7c35bf88ee9fe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



