### PR TITLE
feat: add time provider package

### DIFF
--- a/cue/cuex/compiler.go
+++ b/cue/cuex/compiler.go
@@ -33,6 +33,7 @@ import (
 	cueext "github.com/kubevela/pkg/cue/cuex/providers/cue"
 	"github.com/kubevela/pkg/cue/cuex/providers/http"
 	"github.com/kubevela/pkg/cue/cuex/providers/kube"
+	timeext "github.com/kubevela/pkg/cue/cuex/providers/time"
 	cuexruntime "github.com/kubevela/pkg/cue/cuex/runtime"
 	"github.com/kubevela/pkg/cue/util"
 	"github.com/kubevela/pkg/util/runtime"
@@ -216,6 +217,7 @@ func NewCompilerWithDefaultInternalPackages() *Compiler {
 		http.Package,
 		kube.Package,
 		cueext.Package,
+		timeext.Package,
 	)
 }
 

--- a/cue/cuex/providers/time/time.cue
+++ b/cue/cuex/providers/time/time.cue
@@ -1,0 +1,31 @@
+package time
+
+#DateToTimestamp: {
+	#do:       "timestamp"
+	#provider: "time"
+
+	$params: {
+		date:   string
+		layout: *"" | string
+	}
+
+	$returns?: {
+		timestamp: int64
+	}
+	...
+}
+
+#TimestampToDate: {
+	#do:       "date"
+	#provider: "time"
+
+	$params: {
+		timestamp: int64
+		layout:    *"" | string
+	}
+
+	$returns?: {
+		date: string
+	}
+	...
+}

--- a/cue/cuex/providers/time/time.go
+++ b/cue/cuex/providers/time/time.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2021. The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package time
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"time"
+
+	"github.com/kubevela/pkg/cue/cuex/providers"
+	cuexruntime "github.com/kubevela/pkg/cue/cuex/runtime"
+	"github.com/kubevela/pkg/util/runtime"
+)
+
+// TimestampVars .
+type TimestampVars struct {
+	Date   string `json:"date"`
+	Layout string `json:"layout,omitempty"`
+}
+
+// TimestampReturnVars .
+type TimestampReturnVars struct {
+	Timestamp int64 `json:"timestamp"`
+}
+
+// TimestampParams .
+type TimestampParams = providers.Params[TimestampVars]
+
+// TimestampReturns .
+type TimestampReturns = providers.Returns[TimestampReturnVars]
+
+// Timestamp convert date to timestamp
+func Timestamp(_ context.Context, params *TimestampParams) (*TimestampReturns, error) {
+	date := params.Params.Date
+	layout := params.Params.Layout
+	if date == "" {
+		return nil, fmt.Errorf("empty date to convert")
+	}
+	if layout == "" {
+		layout = time.RFC3339
+	}
+	t, err := time.Parse(layout, date)
+	if err != nil {
+		return nil, err
+	}
+	return &TimestampReturns{
+		Returns: TimestampReturnVars{
+			Timestamp: t.Unix(),
+		},
+	}, nil
+}
+
+// DateVars .
+type DateVars struct {
+	Timestamp int64  `json:"timestamp"`
+	Layout    string `json:"layout,omitempty"`
+}
+
+// DateReturnVars .
+type DateReturnVars struct {
+	Date string `json:"date"`
+}
+
+// DateParams .
+type DateParams = providers.Params[DateVars]
+
+// DateReturns .
+type DateReturns = providers.Returns[DateReturnVars]
+
+// Date convert timestamp to date
+func Date(_ context.Context, params *DateParams) (*DateReturns, error) {
+	timestamp := params.Params.Timestamp
+	layout := params.Params.Layout
+	if layout == "" {
+		layout = time.RFC3339
+	}
+	t := time.Unix(timestamp, 0)
+	return &DateReturns{
+		Returns: DateReturnVars{
+			Date: t.UTC().Format(layout),
+		},
+	}, nil
+}
+
+// ProviderName .
+const ProviderName = "time"
+
+//go:embed time.cue
+var template string
+
+// Package .
+var Package = runtime.Must(cuexruntime.NewInternalPackage(ProviderName, template, map[string]cuexruntime.ProviderFn{
+	"timestamp": cuexruntime.GenericProviderFn[TimestampParams, TimestampReturns](Timestamp),
+	"date":      cuexruntime.GenericProviderFn[DateParams, DateReturns](Date),
+}))
+
+// GetTemplate return the template
+func GetTemplate() string {
+	return template
+}
+
+// GetProviders return the provider
+func GetProviders() map[string]cuexruntime.ProviderFn {
+	return map[string]cuexruntime.ProviderFn{
+		"timestamp": cuexruntime.GenericProviderFn[TimestampParams, TimestampReturns](Timestamp),
+		"date":      cuexruntime.GenericProviderFn[DateParams, DateReturns](Date),
+	}
+}

--- a/cue/cuex/providers/time/time_test.go
+++ b/cue/cuex/providers/time/time_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2021. The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package time
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimestamp(t *testing.T) {
+	ctx := context.Background()
+	testcases := map[string]struct {
+		from        TimestampVars
+		expected    int64
+		expectedErr error
+	}{
+		"test convert date with default time layout": {
+			from: TimestampVars{
+				Date: "2021-11-07T01:47:51Z",
+			},
+			expected:    1636249671,
+			expectedErr: nil,
+		},
+		"test convert date with RFC3339 layout": {
+			from: TimestampVars{
+				Date:   "2021-11-07T01:47:51Z",
+				Layout: "2006-01-02T15:04:05Z07:00",
+			},
+			expected:    1636249671,
+			expectedErr: nil,
+		},
+		"test convert date with RFC1123 layout": {
+			from: TimestampVars{
+				Date:   "Fri, 01 Mar 2019 15:00:00 GMT",
+				Layout: "Mon, 02 Jan 2006 15:04:05 MST",
+			},
+			expected:    1551452400,
+			expectedErr: nil,
+		},
+		"test convert without date": {
+			from:        TimestampVars{},
+			expected:    0,
+			expectedErr: fmt.Errorf("empty date to convert"),
+		},
+		"test convert date with wrong time layout": {
+			from: TimestampVars{
+				Date:   "2021-11-07T01:47:51Z",
+				Layout: "Mon, 02 Jan 2006 15:04:05 MST",
+			},
+			expected:    0,
+			expectedErr: errors.New(`parsing time "2021-11-07T01:47:51Z" as "Mon, 02 Jan 2006 15:04:05 MST": cannot parse "2021-11-07T01:47:51Z" as "Mon"`),
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			res, err := Timestamp(ctx, &TimestampParams{
+				Params: tc.from,
+			})
+			if tc.expectedErr != nil {
+				r.Equal(tc.expectedErr.Error(), err.Error())
+				return
+			}
+			r.NoError(err)
+			r.Equal(tc.expected, res.Returns.Timestamp)
+		})
+	}
+}
+
+func TestDate(t *testing.T) {
+	ctx := context.Background()
+	testcases := map[string]struct {
+		from     DateVars
+		expected string
+	}{
+		"test convert timestamp to default time layout": {
+			from: DateVars{
+				Timestamp: 1636249671,
+			},
+			expected: "2021-11-07T01:47:51Z",
+		},
+		"test convert date to RFC3339 layout": {
+			from: DateVars{
+				Timestamp: 1636249671,
+				Layout:    "2006-01-02T15:04:05Z07:00",
+			},
+			expected: "2021-11-07T01:47:51Z",
+		},
+		"test convert date to RFC1123 layout": {
+			from: DateVars{
+				Timestamp: 1551452400,
+				Layout:    "Mon, 02 Jan 2006 15:04:05 MST",
+			},
+			expected: "Fri, 01 Mar 2019 15:00:00 UTC",
+		},
+		"test convert without timestamp": {
+			from:     DateVars{},
+			expected: "1970-01-01T00:00:00Z",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			r := require.New(t)
+			res, err := Date(ctx, &DateParams{
+				Params: tc.from,
+			})
+			r.NoError(err)
+			r.Equal(tc.expected, res.Returns.Date)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a built-in time provider for CUEX to convert between dates and UNIX timestamps with optional layouts, and register it in the default internal packages. This supports GWCP-94846 by expanding built-in packages used in testing.

- **New Features**
  - Added providers/time with two ops: "timestamp" (date → int64) and "date" (int64 → string), defaulting to RFC3339 and UTC.
  - Exposed CUE templates: #DateToTimestamp and #TimestampToDate with optional layout params.
  - Registered timeext.Package in the compiler’s default internal packages.
  - Added unit tests covering RFC3339/RFC1123, empty inputs, and error cases.

<sup>Written for commit e1202e34baabe792333f2d3b83882fece659744f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

