### PR TITLE
Feat: Introdue cache interface.

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -5,7 +5,7 @@ import "time"
 // Cache interface defines the methods for a cache implementation.
 type Cache[K comparable] interface {
 	// Get retrieves a value from the cache by key.
-	Get(key K) (value interface{}, expired bool)
+	Get(key K) (value interface{}, found bool)
 
 	// Put adds a value to the cache with the specified key and expiration time.
 	Put(key K, value interface{}, expiration time.Duration)

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -3,13 +3,13 @@ package cache
 import "time"
 
 // Cache interface defines the methods for a cache implementation.
-type Cache interface {
+type Cache[K comparable] interface {
 	// Get retrieves a value from the cache by key.
-	Get(key interface{}) (value interface{})
+	Get(key K) (value interface{}, expired bool)
 
 	// Put adds a value to the cache with the specified key and expiration time.
-	Put(key, value interface{}, expiration time.Duration)
+	Put(key K, value interface{}, expiration time.Duration)
 
 	// Delete removes a value from the cache by key.
-	Delete(key interface{})
+	Delete(key K)
 }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,15 @@
+package cache
+
+import "time"
+
+// Cache interface defines the methods for a cache implementation.
+type Cache interface {
+	// Get retrieves a value from the cache by key.
+	Get(key interface{}) (value interface{})
+
+	// Put adds a value to the cache with the specified key and expiration time.
+	Put(key, value interface{}, expiration time.Duration)
+
+	// Delete removes a value from the cache by key.
+	Delete(key interface{})
+}

--- a/cache/map.go
+++ b/cache/map.go
@@ -62,7 +62,7 @@ func (m *MemoryCacheStore[K]) run(ctx context.Context) {
 		case <-ticker.C:
 			m.store.Range(func(key, value interface{}) bool {
 				if value.(*memoryCache).IsExpired() {
-					m.store.Delete(key)
+					m.store.CompareAndDelete(key, value)
 				}
 				return true
 			})
@@ -71,12 +71,12 @@ func (m *MemoryCacheStore[K]) run(ctx context.Context) {
 }
 
 // Get cache data from store, if cache data is expired, return nil
-func (m *MemoryCacheStore[K]) Get(key K) (value interface{}, expired bool) {
+func (m *MemoryCacheStore[K]) Get(key K) (value interface{}, found bool) {
 	mc, ok := m.store.Load(key)
 	if ok && !mc.(*memoryCache).IsExpired() {
-		return mc.(*memoryCache).GetData(), false
+		return mc.(*memoryCache).GetData(), true
 	}
-	return nil, true
+	return nil, false
 }
 
 // Put cache data, if cacheDuration>0, store will clear data after timeout.

--- a/cache/map.go
+++ b/cache/map.go
@@ -38,13 +38,13 @@ func (m *memoryCache) GetData() interface{} {
 }
 
 // MemoryCacheStore memory cache store
-type MemoryCacheStore struct {
+type MemoryCacheStore[K comparable] struct {
 	store sync.Map
 }
 
 // NewMemoryCacheStore memory cache store
-func NewMemoryCacheStore(ctx context.Context) *MemoryCacheStore {
-	mcs := &MemoryCacheStore{
+func NewMemoryCacheStore[K comparable](ctx context.Context) *MemoryCacheStore[K] {
+	mcs := &MemoryCacheStore[K]{
 		store: sync.Map{},
 	}
 	go mcs.run(ctx)
@@ -52,7 +52,7 @@ func NewMemoryCacheStore(ctx context.Context) *MemoryCacheStore {
 }
 
 // run start a goroutine to clear expired cache data
-func (m *MemoryCacheStore) run(ctx context.Context) {
+func (m *MemoryCacheStore[K]) run(ctx context.Context) {
 	ticker := time.NewTicker(DefaultSweepInterval)
 	defer ticker.Stop()
 	for {
@@ -71,21 +71,21 @@ func (m *MemoryCacheStore) run(ctx context.Context) {
 }
 
 // Get cache data from store, if cache data is expired, return nil
-func (m *MemoryCacheStore) Get(key interface{}) (value interface{}) {
+func (m *MemoryCacheStore[K]) Get(key K) (value interface{}, expired bool) {
 	mc, ok := m.store.Load(key)
 	if ok && !mc.(*memoryCache).IsExpired() {
-		return mc.(*memoryCache).GetData()
+		return mc.(*memoryCache).GetData(), false
 	}
-	return nil
+	return nil, true
 }
 
 // Put cache data, if cacheDuration>0, store will clear data after timeout.
-func (m *MemoryCacheStore) Put(key, value interface{}, cacheDuration time.Duration) {
+func (m *MemoryCacheStore[K]) Put(key K, value interface{}, cacheDuration time.Duration) {
 	mc := NewMemoryCache(value, cacheDuration)
 	m.store.Store(key, mc)
 }
 
 // Delete cache data from store
-func (m *MemoryCacheStore) Delete(key interface{}) {
+func (m *MemoryCacheStore[K]) Delete(key K) {
 	m.store.Delete(key)
 }

--- a/cache/map.go
+++ b/cache/map.go
@@ -1,0 +1,91 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultSweepInterval Cache default sweep interval
+	DefaultSweepInterval = time.Second * 3
+)
+
+// memoryCache memory cache, support time expired
+type memoryCache struct {
+	data          interface{}
+	cacheDuration time.Duration
+	startTime     time.Time
+}
+
+// NewMemoryCache new memory cache instance
+func NewMemoryCache(data interface{}, cacheDuration time.Duration) *memoryCache {
+	mc := &memoryCache{data: data, cacheDuration: cacheDuration, startTime: time.Now()}
+	return mc
+}
+
+// IsExpired whether the cache data expires
+func (m *memoryCache) IsExpired() bool {
+	if m.cacheDuration <= 0 {
+		return false
+	}
+	return time.Now().After(m.startTime.Add(m.cacheDuration))
+}
+
+// GetData get cache data
+func (m *memoryCache) GetData() interface{} {
+	return m.data
+}
+
+// MemoryCacheStore memory cache store
+type MemoryCacheStore struct {
+	store sync.Map
+}
+
+// NewMemoryCacheStore memory cache store
+func NewMemoryCacheStore(ctx context.Context) *MemoryCacheStore {
+	mcs := &MemoryCacheStore{
+		store: sync.Map{},
+	}
+	go mcs.run(ctx)
+	return mcs
+}
+
+// run start a goroutine to clear expired cache data
+func (m *MemoryCacheStore) run(ctx context.Context) {
+	ticker := time.NewTicker(DefaultSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.store.Range(func(key, value interface{}) bool {
+				if value.(*memoryCache).IsExpired() {
+					m.store.Delete(key)
+				}
+				return true
+			})
+		}
+	}
+}
+
+// Get cache data from store, if cache data is expired, return nil
+func (m *MemoryCacheStore) Get(key interface{}) (value interface{}) {
+	mc, ok := m.store.Load(key)
+	if ok && !mc.(*memoryCache).IsExpired() {
+		return mc.(*memoryCache).GetData()
+	}
+	return nil
+}
+
+// Put cache data, if cacheDuration>0, store will clear data after timeout.
+func (m *MemoryCacheStore) Put(key, value interface{}, cacheDuration time.Duration) {
+	mc := NewMemoryCache(value, cacheDuration)
+	m.store.Store(key, mc)
+}
+
+// Delete cache data from store
+func (m *MemoryCacheStore) Delete(key interface{}) {
+	m.store.Delete(key)
+}

--- a/cache/map_test.go
+++ b/cache/map_test.go
@@ -43,26 +43,26 @@ var _ = Describe("Test cache utils", func() {
 		store.Put("test2", "test data", 0)
 		store.Put("test3", "test data", -1)
 		time.Sleep(3 * time.Second)
-		value, expired := store.Get("test")
+		value, found := store.Get("test")
 		Expect(value).Should(BeNil())
-		Expect(expired).Should(BeTrue())
+		Expect(found).Should(BeFalse())
 
-		value, expired = store.Get("test2")
+		value, found = store.Get("test2")
 		Expect(value).Should(Equal("test data"))
-		Expect(expired).Should(BeFalse())
+		Expect(found).Should(BeTrue())
 
-		value, expired = store.Get("test3")
+		value, found = store.Get("test3")
 		Expect(value).Should(Equal("test data"))
-		Expect(expired).Should(BeFalse())
+		Expect(found).Should(BeTrue())
 	})
 
 	It("test cache store delete key", func() {
 		store := NewMemoryCacheStore[string](context.TODO())
 		store.Put("test", "test data", time.Minute*2)
 		store.Delete("test")
-		value, expired := store.Get("test")
+		value, found := store.Get("test")
 		Expect(value).Should(BeNil())
-		Expect(expired).Should(BeTrue())
+		Expect(found).Should(BeFalse())
 	})
 
 	It("test cache store with multiple keys", func() {
@@ -74,8 +74,8 @@ var _ = Describe("Test cache utils", func() {
 
 		for i := 0; i < 100; i++ {
 			key := "key-" + strconv.Itoa(i)
-			value, expired := store.Get(key)
-			Expect(expired).Should(BeFalse())
+			value, found := store.Get(key)
+			Expect(found).Should(BeTrue())
 			Expect(value).Should(Equal(i))
 		}
 	})
@@ -83,13 +83,13 @@ var _ = Describe("Test cache utils", func() {
 	It("test cache store overwrite value", func() {
 		store := NewMemoryCacheStore[string](context.TODO())
 		store.Put("rw", "v1", time.Second)
-		value, expired := store.Get("rw")
-		Expect(expired).Should(BeFalse())
+		value, found := store.Get("rw")
+		Expect(found).Should(BeTrue())
 		Expect(value).Should(Equal("v1"))
 
 		store.Put("rw", "v2", time.Second)
-		value, expired = store.Get("rw")
-		Expect(expired).Should(BeFalse())
+		value, found = store.Get("rw")
+		Expect(found).Should(BeTrue())
 		Expect(value).Should(Equal("v2"))
 	})
 })

--- a/cache/map_test.go
+++ b/cache/map_test.go
@@ -1,0 +1,78 @@
+package cache
+
+/*
+Copyright 2021 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test cache utils", func() {
+	It("should return false for IsExpired()", func() {
+		c := NewMemoryCache("test", 10*time.Hour)
+		Expect(c.IsExpired()).Should(BeFalse())
+	})
+
+	It("test cache store", func() {
+		store := NewMemoryCacheStore(context.TODO())
+		store.Put("test", "test data", time.Second*2)
+		store.Put("test2", "test data", 0)
+		store.Put("test3", "test data", -1)
+		time.Sleep(3 * time.Second)
+		Expect(store.Get("test")).Should(BeNil())
+		Expect(store.Get("test2")).Should(Equal("test data"))
+		Expect(store.Get("test3")).Should(Equal("test data"))
+	})
+
+	It("test cache store delete key", func() {
+		store := NewMemoryCacheStore(context.TODO())
+		store.Put("test", "test data", time.Minute*2)
+		store.Delete("test")
+		Expect(store.Get("test")).Should(BeNil())
+	})
+})
+
+var store *MemoryCacheStore
+
+// BenchmarkWrite
+func BenchmarkWrite(b *testing.B) {
+	store = NewMemoryCacheStore(context.TODO())
+
+	for i := 0; i < b.N; i++ {
+		store.Put(fmt.Sprintf("%d", i), i, 0)
+	}
+}
+
+// BenchmarkRead
+func BenchmarkRead(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		store.Get(fmt.Sprintf("%d", i))
+	}
+}
+
+// BenchmarkRW
+func BenchmarkRW(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		store.Put(fmt.Sprintf("%d", i), i, 1)
+		store.Get(fmt.Sprintf("%d", i))
+	}
+}

--- a/cache/map_test.go
+++ b/cache/map_test.go
@@ -18,13 +18,18 @@ limitations under the License.
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func TestCache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cache Suite")
+}
 
 var _ = Describe("Test cache utils", func() {
 	It("should return false for IsExpired()", func() {
@@ -33,46 +38,58 @@ var _ = Describe("Test cache utils", func() {
 	})
 
 	It("test cache store", func() {
-		store := NewMemoryCacheStore(context.TODO())
+		store := NewMemoryCacheStore[string](context.TODO())
 		store.Put("test", "test data", time.Second*2)
 		store.Put("test2", "test data", 0)
 		store.Put("test3", "test data", -1)
 		time.Sleep(3 * time.Second)
-		Expect(store.Get("test")).Should(BeNil())
-		Expect(store.Get("test2")).Should(Equal("test data"))
-		Expect(store.Get("test3")).Should(Equal("test data"))
+		value, expired := store.Get("test")
+		Expect(value).Should(BeNil())
+		Expect(expired).Should(BeTrue())
+
+		value, expired = store.Get("test2")
+		Expect(value).Should(Equal("test data"))
+		Expect(expired).Should(BeFalse())
+
+		value, expired = store.Get("test3")
+		Expect(value).Should(Equal("test data"))
+		Expect(expired).Should(BeFalse())
 	})
 
 	It("test cache store delete key", func() {
-		store := NewMemoryCacheStore(context.TODO())
+		store := NewMemoryCacheStore[string](context.TODO())
 		store.Put("test", "test data", time.Minute*2)
 		store.Delete("test")
-		Expect(store.Get("test")).Should(BeNil())
+		value, expired := store.Get("test")
+		Expect(value).Should(BeNil())
+		Expect(expired).Should(BeTrue())
+	})
+
+	It("test cache store with multiple keys", func() {
+		store := NewMemoryCacheStore[string](context.TODO())
+		for i := 0; i < 100; i++ {
+			key := "key-" + strconv.Itoa(i)
+			store.Put(key, i, 0)
+		}
+
+		for i := 0; i < 100; i++ {
+			key := "key-" + strconv.Itoa(i)
+			value, expired := store.Get(key)
+			Expect(expired).Should(BeFalse())
+			Expect(value).Should(Equal(i))
+		}
+	})
+
+	It("test cache store overwrite value", func() {
+		store := NewMemoryCacheStore[string](context.TODO())
+		store.Put("rw", "v1", time.Second)
+		value, expired := store.Get("rw")
+		Expect(expired).Should(BeFalse())
+		Expect(value).Should(Equal("v1"))
+
+		store.Put("rw", "v2", time.Second)
+		value, expired = store.Get("rw")
+		Expect(expired).Should(BeFalse())
+		Expect(value).Should(Equal("v2"))
 	})
 })
-
-var store *MemoryCacheStore
-
-// BenchmarkWrite
-func BenchmarkWrite(b *testing.B) {
-	store = NewMemoryCacheStore(context.TODO())
-
-	for i := 0; i < b.N; i++ {
-		store.Put(fmt.Sprintf("%d", i), i, 0)
-	}
-}
-
-// BenchmarkRead
-func BenchmarkRead(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		store.Get(fmt.Sprintf("%d", i))
-	}
-}
-
-// BenchmarkRW
-func BenchmarkRW(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		store.Put(fmt.Sprintf("%d", i), i, 1)
-		store.Get(fmt.Sprintf("%d", i))
-	}
-}


### PR DESCRIPTION
This PR introduces a generic Cache interface (Put/Get/Delete) package, decoupling consumers from concrete implementations and making a reusable package across KubeVela repo. This enables swapping backends (sync.Map, hashicorp/golang-lru, etc.) without touching consumer code.

The first implementation, `MemoryCache, uses sync.Map` with per-entry TTL and a background eviction goroutine (migrated from the  `kubevela/kubevela/pkg/utils/cache.go` with identical behaviour).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a generic `cache.Cache` and in-memory `MemoryCacheStore` with per-entry TTL and background eviction. Uses a simple Get/Put/Delete API with `found` semantics and context-aware cleanup.

- **New Features**
  - Added `cache.Cache[K comparable]` with `Get(key) (value, found)`, `Put(key, value, expiration)`, and `Delete(key)`.
  - Implemented `MemoryCacheStore` using `sync.Map`, a 3s sweep interval, and context-aware shutdown.
  - Added tests with `github.com/onsi/ginkgo/v2` and `github.com/onsi/gomega` for expiration, non-expiring entries, delete, multi-key, and overwrite.

<sup>Written for commit d0f4239d37291d92e13322936e1a8a080afa9fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kubevela/pkg/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

