### PR TITLE
Chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # This file is a github code protect rule follow the codeowners https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file
 
-controller/         @Somefive @FogDong @anoop2811 @briankane @jguionnet
-multicluster/       @Somefive @chivalryq @anoop2811 @briankane @jguionnet
-monitor/            @Somefive @FogDong @leejanee @anoop2811 @briankane @jguionnet
-util/               @Somefive @FogDong @anoop2811 @briankane @jguionnet
-util/compression    @Somefive @charlie0129 @anoop2811 @briankane @jguionnet
-cue/                @Somefive @FogDong @anoop2811 @briankane @jguionnet
-apis/               @Somefive @FogDong @anoop2811 @briankane @jguionnet
-crds/               @Somefive @FogDong @anoop2811 @briankane @jguionnet
-hack/               @Somefive @FogDong @anoop2811 @briankane @jguionnet
+controller/         @Somefive @FogDong @anoop2811 @briankane @jguionnet @roguepikachu
+multicluster/       @Somefive @chivalryq @anoop2811 @briankane @jguionnet @roguepikachu
+monitor/            @Somefive @FogDong @leejanee @anoop2811 @briankane @jguionnet @roguepikachu
+util/               @Somefive @FogDong @anoop2811 @briankane @jguionnet @roguepikachu
+util/compression    @Somefive @charlie0129 @anoop2811 @briankane @jguionnet @roguepikachu
+cue/                @Somefive @FogDong @anoop2811 @briankane @jguionnet @roguepikachu
+apis/               @Somefive @FogDong @anoop2811 @briankane @jguionnet @roguepikachu
+crds/               @Somefive @FogDong @anoop2811 @briankane @jguionnet @roguepikachu
+hack/               @Somefive @FogDong @anoop2811 @briankane @jguionnet @roguepikachu


### PR DESCRIPTION
## Summary
- Add @roguepikachu to `.github/CODEOWNERS` across pkg paths
- Related: https://github.com/kubevela/community/issues/271
- Related: https://github.com/kubevela/community/pull/272

## Test plan
- [x] Confirm CODEOWNERS entries include @roguepikachu on all owned paths
- [x] Reviewer/maintainer approval


